### PR TITLE
Update \EnsureConfiguration class

### DIFF
--- a/build/phpscripts/Magento/EnsureConfiguration.php
+++ b/build/phpscripts/Magento/EnsureConfiguration.php
@@ -63,6 +63,7 @@ class EnsureConfiguration extends Task
      */
     private function executeConfigSetCommand($path, $value, $scope = false, $scopeCode = false)
     {
+        $value = $this->getProject()->replaceProperties($value);
         $command = $this->getConfigSetCommand($path, $value);
         if ($scope && $scopeCode) {
             $command = $command . " " . $this->getConfigSetScopeParams($scope, $scopeCode);


### PR DESCRIPTION
After last change in this file, https://github.com/staempfli/magento2-builder-tool/commit/15fdc10dfc08a8d1ac3f42b28a17064df4ca636c, **project variables in config.yaml files are not replaced anymore**, due to missing `$this->getProject()->replaceProperties($value)` call.

After adapting my config.yaml file to new format, it looks like this:
<img width="421" alt="captura de pantalla 2018-05-17 a las 18 55 49" src="https://user-images.githubusercontent.com/17545750/40192205-015708c0-5a04-11e8-9a13-5b0278883ec3.png">

This is the result before applying change proposed in this PR:
<img width="1354" alt="captura de pantalla 2018-05-17 a las 18 50 57" src="https://user-images.githubusercontent.com/17545750/40192271-2be22b60-5a04-11e8-9f12-43ee877d8f25.png">

And this, the expected behaviour, after applying proposed change:
<img width="827" alt="captura de pantalla 2018-05-17 a las 18 57 11" src="https://user-images.githubusercontent.com/17545750/40192313-3faac2a6-5a04-11e8-9129-bf2c4f1d2999.png">
